### PR TITLE
Fix issue with auto-puncutation for keyboardkit

### DIFF
--- a/kebbie/emulator.py
+++ b/kebbie/emulator.py
@@ -393,6 +393,11 @@ class Emulator:
             # (which is what we want). On iOS it will not, we need to do it "manually"
             if self.platform == IOS:
                 self.typing_field.clear()
+            if self.keyboard == KBKIT:
+                # In the case of KeyboardKit, after pasting the content, typing a space
+                # trigger a punctuation (because previous context may end with a space)
+                # To avoid this behavior, break the cycle by typing a backspace
+                self._tap(self.layout["lowercase"]["backspace"])
             self.typing_field.send_keys(text)
             self.kb_is_upper = len(text) > 1 and self._is_eos(text[-2]) and text.endswith(" ")
             self.last_char_is_space = text.endswith(" ")


### PR DESCRIPTION
<!--- The title of your PR should be short, focused, and to the point. Usually, the title is a complete sentence written as it was an order (imperative sentence) --->

## 🔍️ Description

When running keyboard kit on the full tasks, somehow a lot of punctuation was showing in the middle of the sentence (which make the next prediction wrong, with uppercase, etc...).

Turn out, after a context is typed, it ends with a space. Then we clean the input text, paste the new context, and type a space. The keyboard detects this as a double-space, which is translated to a punctuation.

No matter what we change in the settings, this behavior can't be changed (from the demo of KeyboardKit at least).

So this PR fix this by typing a backspace right after cleaning the text field (so it has no effect whatsoever), which breaks the cycle. So no punctuation is added.

## 🧐 Context

<!--- Provide additional context, like why this PR is needed (what was wrong with previous code) --->

## ⚠️ Side-effects / Shortcomings

<!--- Any side-effects or shortcomings reviewers should be aware of ? --->

## ✅ How this was tested ?

<!--- Describe the tests you ran to verify your changes. It's also the place to provide instructions for reproducing the tests / relevant details of the test configuration. --->

## 🌱 Checklist

<!--- Add here any task left to do before the PR is ready for review / merging --->
- [ ] Perform self-review of my own code
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Update the documentation accordingly to the new code
- [ ] Lint / format the code
- [ ] Update existing tests / Add new tests
- [ ] Tests are passing locally
