### PR TITLE
Add support for Yandex Android keyboard

### DIFF
--- a/kebbie/cmd.py
+++ b/kebbie/cmd.py
@@ -28,7 +28,7 @@ def instantiate_correctors(
     Returns:
         The list of created Correctors.
     """
-    if keyboard in ["gboard", "tappa", "swiftkey"]:
+    if keyboard in ["gboard", "tappa", "swiftkey", "anysoft"]:
         # Android keyboards
         return [
             EmulatorCorrector(
@@ -68,7 +68,7 @@ def common_args(parser: argparse.ArgumentParser):
         dest="keyboard",
         type=str,
         required=True,
-        choices=["gboard", "ios", "kbkitpro", "kbkitoss", "tappa", "fleksy", "swiftkey"],
+        choices=["gboard", "ios", "kbkitpro", "kbkitoss", "tappa", "fleksy", "swiftkey", "anysoft"],
         help="Which keyboard, to be tested, is currently installed on the emulator.",
     )
 

--- a/kebbie/cmd.py
+++ b/kebbie/cmd.py
@@ -28,7 +28,7 @@ def instantiate_correctors(
     Returns:
         The list of created Correctors.
     """
-    if keyboard in ["gboard", "tappa", "swiftkey", "anysoft"]:
+    if keyboard in ["gboard", "tappa", "swiftkey", "yandex"]:
         # Android keyboards
         return [
             EmulatorCorrector(
@@ -68,7 +68,7 @@ def common_args(parser: argparse.ArgumentParser):
         dest="keyboard",
         type=str,
         required=True,
-        choices=["gboard", "ios", "kbkitpro", "kbkitoss", "tappa", "fleksy", "swiftkey", "anysoft"],
+        choices=["gboard", "ios", "kbkitpro", "kbkitoss", "tappa", "fleksy", "swiftkey", "yandex"],
         help="Which keyboard, to be tested, is currently installed on the emulator.",
     )
 

--- a/kebbie/emulator.py
+++ b/kebbie/emulator.py
@@ -1121,6 +1121,7 @@ class SwiftkeyLayoutDetector(LayoutDetector):
 
         return suggestions
 
+
 class YandexLayoutDetector(LayoutDetector):
     """Layout detector for the Yandex keyboard. See `LayoutDetector` for more
     information.


### PR DESCRIPTION
Add support for Yandex Android keyboard 

## 🔍️ Description

Added yandex to the available Android keyboards and the Xpaths needed to map the keys and suggestions.

## 🧐 Context

Only for Android devices (emulators and real devices)

## ⚠️ Side-effects / Shortcomings

The numbers layout is not mapped

## ✅ How this was tested ?

To map the keys run `kebbie show_layout -K yandex`
To evaluate the keyboard run `kebbie evaluate -K yandex`


## 🌱 Checklist

<!--- Add here any task left to do before the PR is ready for review / merging --->
- [ ] Perform self-review of my own code
- [ ] Comment the code, particularly in hard-to-understand areas
- [X] Update the documentation accordingly to the new code
- [ ] Lint / format the code
- [ ] Update existing tests / Add new tests
- [X] Tests are passing locally
